### PR TITLE
fix package.json `main` reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/EricWittmann/oai-ts-core"
   },
-  "main": "bundles/OAI.umd.min.js",
+  "main": "bundles/OAI.umd.js",
   "module": "index.js",
   "typings": "index.d.ts",
   "typescript": {


### PR DESCRIPTION
Noticed whilst trying to use this module in node that main was pointing to a non existent bundle. This PR fixes that, allowing this module to be used in NodeJS environments.

Probably fixes #11 