### PR TITLE
feat(oas3-type-validation) : Added basic type validation

### DIFF
--- a/src/validation/3.0/invalid-property-type.rule.ts
+++ b/src/validation/3.0/invalid-property-type.rule.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2017 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Oas30ValidationRule } from "./common.rule";
+import { OasValidationRuleUtil } from "../validation";
+import { Oas30Schema, Oas30SchemaDefinition, Oas30ItemsSchema, Oas30PropertySchema, Oas30AllOfSchema, Oas30AnyOfSchema, Oas30OneOfSchema, Oas30NotSchema, Oas30AdditionalPropertiesSchema } from "../../models/3.0/schema.model";
+
+const allowedTypes = ["string", "number", "integer", "boolean", "array", "object"]
+/**
+ * Implements the Invalid Property Type validation rule.  This rule is responsible
+ * for reporting whenever the **type** and **items** of a property fails to conform to the required
+ * format defined by the specification
+ */
+export class Oas30InvalidPropertyTypeValidationRule extends Oas30ValidationRule {
+
+    /**
+     * Returns true if the type node has a valid type.
+     * @param type
+     * @return {boolean}
+     */
+    private isValidType(type: string): boolean {
+        if (this.hasValue(type)) {
+            return OasValidationRuleUtil.isValidEnumItem(type, allowedTypes)
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if the type is array and items is defined
+     * @param type
+     * @return {boolean}
+     */
+    private isValidItems(node: Oas30Schema): boolean {
+        const { type, items } = node;
+        if (type == 'array' && !this.hasValue(items)) return false;
+        if (type !== 'array' && this.hasValue(items)) return false;
+        return true;
+    }
+
+    public visitSchema(node: Oas30Schema) {
+        this.reportIfInvalid("PT-3-001", this.isValidType(node.type), node, "type",
+            `Schema Definition type must be one of: ${allowedTypes.join(", ")}`);
+
+        this.reportIfInvalid("PA-3-001", this.isValidItems(node), node, "items",
+            `Schema Definition items must be present if and only if type is of array`);
+    }
+
+    public visitAllOfSchema(node: Oas30AllOfSchema): void { this.visitSchema(node); }
+    public visitAnyOfSchema(node: Oas30AnyOfSchema): void { this.visitSchema(node); }
+    public visitOneOfSchema(node: Oas30OneOfSchema): void { this.visitSchema(node); }
+    public visitNotSchema(node: Oas30NotSchema): void { this.visitSchema(node); }
+    public visitPropertySchema(node: Oas30PropertySchema): void { this.visitSchema(node); }
+    public visitItemsSchema(node: Oas30ItemsSchema): void { this.visitSchema(node); }
+    public visitAdditionalPropertiesSchema(node: Oas30AdditionalPropertiesSchema): void { this.visitSchema(node); }
+    public visitSchemaDefinition(node: Oas30SchemaDefinition): void { this.visitSchema(node); }
+}

--- a/src/validation/validation.visitor.ts
+++ b/src/validation/validation.visitor.ts
@@ -41,6 +41,7 @@ import {Oas30InvalidReferenceValidationRule} from "./3.0/invalid-reference.rule"
 import {Oas30MutuallyExclusiveValidationRule} from "./3.0/mutually-exclusive.rule";
 import {Oas30RequiredPropertyValidationRule} from "./3.0/required-property.rule";
 import {Oas30UniquenessValidationRule} from "./3.0/uniqueness.rule";
+import { Oas30InvalidPropertyTypeValidationRule } from "./3.0/invalid-property-type.rule";
 
 /**
  * Visitor used to clear validation problems.  This is typically done just before
@@ -141,6 +142,7 @@ export class Oas30ValidationVisitor extends Oas30CompositeVisitor implements IOa
         this.addVisitors([
             new Oas30InvalidPropertyFormatValidationRule(this),
             new Oas30IgnoredPropertyNameValidationRule(this),
+            new Oas30InvalidPropertyTypeValidationRule(this),
             new Oas30InvalidPropertyNameValidationRule(this),
             new Oas30InvalidPropertyValueValidationRule(this),
             new Oas30InvalidReferenceValidationRule(this),

--- a/tests/fixtures/validation/3.0/invalid-property-type.json
+++ b/tests/fixtures/validation/3.0/invalid-property-type.json
@@ -1,0 +1,245 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/api"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "invalid"
+          },
+          "tags": {
+            "type": "array"
+          },
+          "nickNames": {
+            "type": "array",
+            "items":{
+              "type": "invalid"
+            }
+          }
+        }
+      },
+      "Error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -311,6 +311,24 @@ describe("Validation (3.0)", () => {
         assertValidationOutput(actual, expected);
     });
 
+    it("Invalid Property Type", () => {
+        let json: any = readJSON('tests/fixtures/validation/3.0/invalid-property-type.json'); 
+        let document: Oas30Document = <Oas30Document> library.createDocument(json);
+
+        let node: OasNode = document;
+        let errors: OasValidationProblem[] = library.validate(node);
+
+        let actual: string = errorsAsString(errors);
+        let expected: string =[
+            '[PA-3-001] |2| {/paths[/pets]/get/responses[200]/content[application/json]/schema->items} :: Schema Definition items must be present if and only if type is of array',
+            '[PT-3-001] |2| {/components/schemas[NewPet]/properties[name]->type} :: Schema Definition type must be one of: string, number, integer, boolean, array, object',
+            '[PA-3-001] |2| {/components/schemas[NewPet]/properties[tags]->items} :: Schema Definition items must be present if and only if type is of array',
+            '[PT-3-001] |2| {/components/schemas[NewPet]/properties[nickNames]/items->type} :: Schema Definition type must be one of: string, number, integer, boolean, array, object'
+        ].join('\n')
+
+        assertValidationOutput(actual, expected);
+    });
+
     it("Invalid Property Name", () => {
         let json: any = readJSON('tests/fixtures/validation/3.0/invalid-property-name.json');
         let document: Oas30Document = <Oas30Document> library.createDocument(json);


### PR DESCRIPTION
This issue addresses #10 to validate `type` and `items` fields for oas3 schemas