### PR TITLE
Included additional check for input JSON object's openapi property's …

### DIFF
--- a/src/factories/document.factory.ts
+++ b/src/factories/document.factory.ts
@@ -65,7 +65,7 @@ export class OasDocumentFactory {
         if (oasObject.swagger && oasObject.swagger === "2.0") {
             let reader: Oas20JS2ModelReader = new Oas20JS2ModelReader();
             return reader.read(oasObject);
-        } else if (oasObject.openapi && oasObject.openapi.indexOf("3.") === 0) {
+        } else if (oasObject.openapi && (typeof oasObject.openapi === "string") && oasObject.openapi.indexOf("3.") === 0) {
             let reader: Oas30JS2ModelReader = new Oas30JS2ModelReader();
             return reader.read(oasObject);
         } else {


### PR DESCRIPTION
…type to be string when creating the document - absense of this check leads to errors for cases when openapi property is e.g a number like 4 for which indexOf function is not defined.