### PR TITLE
Expanded tests for path validations. Support for prefixed variables e…

### DIFF
--- a/src/validation/3.0/invalid-property-name.rule.ts
+++ b/src/validation/3.0/invalid-property-name.rule.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Oas30ValidationRule} from "./common.rule";
+import {Oas30ValidationRule, Oas30PathValidationRule, PathSegment} from "./common.rule";
 import {OasValidationRuleUtil} from "../validation";
 import {Oas30Link, Oas30LinkDefinition} from "../../models/3.0/link.model";
 import {Oas30Callback, Oas30CallbackDefinition} from "../../models/3.0/callback.model";
@@ -66,12 +66,20 @@ import {Oas30XML} from "../../models/3.0/xml.model";
 import {Oas30Tag} from "../../models/3.0/tag.model";
 import {Oas30ExternalDocumentation} from "../../models/3.0/external-documentation.model";
 
+type IdenticalPathRecord = {
+    identicalReported: boolean,
+    pathSegments: PathSegment[],
+    node: Oas30PathItem,
+};
+
 /**
  * Implements the Invalid Property Name validation rule.  This rule is responsible
  * for reporting whenever the **name** of a property fails to conform to the required
  * format defined by the specification.
  */
-export class Oas30InvalidPropertyNameValidationRule extends Oas30ValidationRule {
+export class Oas30InvalidPropertyNameValidationRule extends Oas30PathValidationRule {
+
+    private indexedPathSegments: any = {};
 
     /**
      * Returns true if the definition name is valid.
@@ -96,9 +104,139 @@ export class Oas30InvalidPropertyNameValidationRule extends Oas30ValidationRule 
         return !this.isNullOrUndefined(schema.property(propertyName));
     }
 
+    /**
+     * Finds all occurences of path segments that are empty.
+     * i.e. they neither have a prefix nor a path variable within curly braces.
+     *
+     * @param pathSegments
+     * @return {PathSegment[]}
+     */
+    private findEmptySegmentsInPath(pathSegments: PathSegment[]) {
+        return pathSegments.filter(pathSegment => {
+            return pathSegment.prefix === "" && pathSegment.formalName === undefined;
+        });
+    }
+    
+    /**
+     * Finds path segments that are duplicates i.e. they have the same formal name used across multiple segments.
+     * For example, in a path like /prefix/{var1}/{var1}, var1 is used in multiple segments.
+     *
+     * @param pathSegments
+     * @return {PathSegment[]}
+     */
+    private findDuplicateParametersInPath(pathSegments: PathSegment[]) {
+        const uniq = pathSegments
+            .filter(pathSegment => {
+                return pathSegment.formalName !== undefined;
+            })
+            .map(pathSegment => {
+                return { parameter: pathSegment.formalName, count: 1 };
+            })
+            .reduce((parameterCounts, segmentEntry) => {
+                parameterCounts[segmentEntry.parameter] = (parameterCounts[segmentEntry.parameter] || 0) + segmentEntry.count;
+                return parameterCounts;
+            }, {});
+        return Object.keys(uniq).filter(a => uniq[a] > 1);
+    }
+
+    /**
+     * Utility function to find other paths that are semantically similar to the path that is being checked against.
+     * Two paths the differ only in formal parameter name are considered identical.
+     * For example, paths /test/{var1} and /test/{var2} are identical.
+     * See OAS 3 Specification's Path Templates section for more details.
+     *
+     * @param segment1
+     * @param segment2
+     * @return {boolean}
+     */
+    private findIdenticalPaths(pathToCheck: string, pathToSegmentsMap: any): string[] {
+        const identicalPaths: string[] = [];
+        const pathSegments: PathSegment[] = pathToSegmentsMap[pathToCheck].pathSegments;
+        Object.keys(pathToSegmentsMap)
+        .filter(checkAgainst => checkAgainst !== pathToCheck)
+        .forEach(checkAgainst => {
+            let segmentsIdential: boolean = true;
+            const pathSegmentsToCheckAgainst: PathSegment[] = pathToSegmentsMap[checkAgainst].pathSegments;
+            if (pathSegments.length !== pathSegmentsToCheckAgainst.length) {
+                segmentsIdential = false;
+            } else {
+                pathSegments.forEach((pathSegment, index) => {
+                    segmentsIdential =
+                    segmentsIdential && this.isSegmentIdentical(pathSegment, pathSegmentsToCheckAgainst[index]);
+                });
+            }
+            if (segmentsIdential === true) {
+                identicalPaths.push(checkAgainst);
+            }
+        });
+        return identicalPaths;
+    }
+
+    /**
+     * Utility function to test the equality of two path segments.
+     * Segments are considered equal if they have same prefixes (if any) and same "normalized name".
+     *
+     * @param segment1
+     * @param segment2
+     * @return {boolean}
+     */
+    private isSegmentIdentical(segment1: PathSegment, segment2: PathSegment): boolean {
+        if (segment1.prefix === segment2.prefix) {
+            if (segment1.normalizedName === undefined && segment2.normalizedName === undefined) {
+                return true;
+            }
+            if (
+                (segment1.normalizedName === undefined && segment2.normalizedName !== undefined) ||
+                (segment1.normalizedName !== undefined && segment2.normalizedName === undefined)
+            ) {
+                return false;
+            }
+            return segment1.normalizedName === segment2.normalizedName;
+        }
+        return false;
+    }
+
     public visitPathItem(node: Oas30PathItem): void {
-        this.reportIfInvalid("PATH-3-004", node.path().indexOf("/") === 0, node, null,
-            `Paths must start with a '/' character.`);
+        const pathTemplate: string = node.path();
+        let hasTemplateErrors = false;
+        let pathSegments: PathSegment[];
+        if (this.isPathWellFormed(pathTemplate) === true) {
+            pathSegments = this.getPathSegments(pathTemplate);
+            const emptySegments = this.findEmptySegmentsInPath(pathSegments);
+            if (emptySegments.length > 0) {
+                this.reportPathError("PATH-3-005", node, "Path templates must not contain empty segments between forward slashes.");
+                hasTemplateErrors = hasTemplateErrors || true;
+            }
+            const duplicateParameters = this.findDuplicateParametersInPath(pathSegments);
+            if (duplicateParameters.length > 0) {
+                this.reportPathError("PATH-3-006", node, `Path template contains duplicate variables (${duplicateParameters.join(", ")}).`, false);
+                hasTemplateErrors = hasTemplateErrors || true;
+            }
+        }
+        else {
+            this.reportPathError("PATH-3-004", node, "Paths template is invalid.");
+            hasTemplateErrors = hasTemplateErrors || true;
+        }
+        if (hasTemplateErrors === false) {
+            const currentPathRecord: IdenticalPathRecord = {
+                identicalReported: false,
+                pathSegments,
+                node,
+            };
+            this.indexedPathSegments[pathTemplate] = currentPathRecord;
+            const identicalPaths = this.findIdenticalPaths(pathTemplate, this.indexedPathSegments);
+            if (identicalPaths.length > 0) {
+                this.reportPathError("PATH-3-007", node, `Path semantically identical to other paths.`, false);
+                currentPathRecord.identicalReported = true;
+                identicalPaths.forEach(path => {
+                    const identicalPathRecord: IdenticalPathRecord = this.indexedPathSegments[path];
+                    if (identicalPathRecord.identicalReported === false) {
+                        this.reportPathError("PATH-3-007", identicalPathRecord.node, `Path semantically identical to other paths.`, false);
+                        identicalPathRecord.identicalReported = true;
+                    }
+                });
+            }
+        }
     }
 
     public visitResponse(node: Oas30Response): void {

--- a/src/validation/3.0/uniqueness.rule.ts
+++ b/src/validation/3.0/uniqueness.rule.ts
@@ -43,7 +43,7 @@ export class Oas30UniquenessValidationRule extends Oas30ValidationRule {
 
     public visitOperation(node: Oas30Operation): void {
         if (this.hasValue(node.operationId)) {
-            let dupes: Oas30Operation[] = this.indexedOperations[node.operationId]
+            let dupes: Oas30Operation[] = this.indexedOperations[node.operationId];
             if (this.hasValue(dupes)) {
                 this.reportIfInvalid("OP-3-002", dupes.length > 1, dupes[0], "operationId",
                     `Operation IDs must be unique across all operations.`);

--- a/tests/fixtures/validation/3.0/invalid-property-name.json
+++ b/tests/fixtures/validation/3.0/invalid-property-name.json
@@ -242,6 +242,316 @@
           }
         }
       }
+    },
+    "/": {
+      "get": {
+        "description": "pathstest1 - root path (/) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/1": {
+      "get": {
+        "description": "pathstest2 - path with single non-parameterized (numeric) segment (/1) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest3": {
+      "get": {
+        "description": "pathstest3 - path with single non-parameterized (string) segment (/pathstest3) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest4/": {
+      "get": {
+        "description": "pathstest4 - path with single non-parameterized segment with trailing slash (/pathstest4/) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest5/{var}": {
+      "get": {
+        "description": "pathstest5 - path with single non-prefixed parameterized segment (/pathstest5/{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest6/{var}/": {
+      "get": {
+        "description": "pathstest6 - path with single non-prefixed parameterized segment with trailing slash (/pathstest6/{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest7{var}": {
+      "get": {
+        "description": "pathstest7 - path with single prefixed parameterized segment (/pathstest7{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest8{var}/": {
+      "get": {
+        "description": "pathstest8 - path with single prefixed parameterized segment with trailing slash (/pathstest8{var}/) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest9/{var}": {
+      "get": {
+        "description": "pathstest9 - path with non-parameterized segment followed by a parameterized segment (/pathstest9/{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/{var}/pathstest10": {
+      "get": {
+        "description": "pathstest10 - path with parameterized segment followed by a non-parameterized segment (/{var}/pathstest10) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "//pathstest11": {
+      "get": {
+        "description": "pathstest11 - path with empty segment (//pathstest11) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "pathstest12": {
+      "get": {
+        "description": "pathstest12 - path with single non-parameterized segment without leading slash (pathstest12) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "{pathstest13}": {
+      "get": {
+        "description": "pathstest13 - path with single non-parameterized segment without leading slash ({pathstest13}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/{{pathstest14}}": {
+      "get": {
+        "description": "pathstest14 - path segment with nested parameterized properties (/{{pathstest14}}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest15/{var1}{var2}": {
+      "get": {
+        "description": "pathstest15 - path segment with multiple parameterized properties (/pathstest15/{var1}{var2}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest16/{var": {
+      "get": {
+        "description": "pathstest16 - path segment with unbalanced left curly brace (/pathstest16/{var) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest17/var}": {
+      "get": {
+        "description": "pathstest17 - path segment with unbalanced right curly brace (/pathstest17/var}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest18/{_var}": {
+      "get": {
+        "description": "pathstest18 - path with parameter name starting with an underscore (/pathstest18/{_var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest19/{1var}": {
+      "get": {
+        "description": "pathstest19 - path with parameter name starting with a digit (/pathstest19/{1var}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest20/{v1ar_2}": {
+      "get": {
+        "description": "pathstest19 - path with parameter name containing a digit in second or later position with underscores (/pathstest20/{v1ar_2}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest21/var{var}": {
+      "get": {
+        "description": "pathstest21 - path with same name used as prefix and parameter (/pathstest21/var{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest22/{var}/{var}": {
+      "get": {
+        "description": "pathstest22 - path with single duplicated parameter (/pathstest22/{var}/{var}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest23/{var1}/{var2}/a{var2}/{var1}": {
+      "get": {
+        "description": "pathstest23 - path with multiple duplicated parameters (/pathstest23/{var1}/{var2/a{var2}/{var1}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest24/var": {
+      "get": {
+        "description": "pathstest24 - two paths with same name used as prefix in one and parameter in another (/pathstest24/var) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest24/{var}": {
+      "get": {
+        "description": "pathstest24 - two paths with same name used as prefix in one and parameter in another (/pathstest24/{var}) - valid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest25": {
+      "get": {
+        "description": "pathstest25 - non parameterized paths that vary only in trailing slash (/pathstest25) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest25/": {
+      "get": {
+        "description": "pathstest25 - non parameterized paths that vary only in trailing slash (/pathstest25/) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest26/{var}": {
+      "get": {
+        "description": "pathstest26 - parameterized paths that vary only in trailing slash (/pathstest26/{var}) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest26/{var}/": {
+      "get": {
+        "description": "pathstest26 - parameterized paths that vary only in trailing slash (/pathstest26/{var}/) - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest27/{var1}": {
+      "get": {
+        "description": "pathstest27 - parameterized paths that vary only in formal parameter names (/pathstest27/{var1}) - See: OAS 3 - Path Template Matching - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
+    },
+    "/pathstest27/{var2}/": {
+      "get": {
+        "description": "pathstest27 - parameterized paths that vary only in formal parameter names (/pathstest27/{var2}) - See: OAS 3 - Path Template Matching - invalid",
+        "responses": {
+          "default": {
+            "description": "..."
+          }
+        }
+      }
     }
   },
   "components": {

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -348,15 +348,31 @@ describe("Validation (3.0)", () => {
     it("Invalid Property Name", () => {
         let json: any = readJSON('tests/fixtures/validation/3.0/invalid-property-name.json');
         let document: Oas30Document = library.createDocument(json) as Oas30Document;
-
+    
         let node: OasNode = document;
         let errors: OasValidationProblem[] = library.validate(node);
-
+    
         let actual: string = errorsAsString(errors);
         let expected: string =
 `[ENC-3-006] |2| {/paths[/enc-3-006]/post/requestBody/content[multipart/mixed]/encoding[missingProperty]->missingProperty} :: Encoding Property "missingProperty" not found in the associated schema.
 [RES-3-001] |2| {/paths[/pets]/get/responses[Success]->null} :: "Success" is not a valid HTTP response status code.
-[PATH-3-004] |2| {/paths[pets/{id}]->null} :: Paths must start with a '/' character.
+[PATH-3-004] |2| {/paths[pets/{id}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-005] |2| {/paths[//pathstest11]->null} :: Path templates must not contain empty segments between forward slashes. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[pathstest12]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[{pathstest13}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[/{{pathstest14}}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[/pathstest15/{var1}{var2}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[/pathstest16/{var]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[/pathstest17/var}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-004] |2| {/paths[/pathstest19/{1var}]->null} :: Paths template is invalid. Path templates must be of the form '/abc', '/{def}/', '/abc/g{def}'.
+[PATH-3-006] |2| {/paths[/pathstest22/{var}/{var}]->null} :: Path template contains duplicate variables (var).
+[PATH-3-006] |2| {/paths[/pathstest23/{var1}/{var2}/a{var2}/{var1}]->null} :: Path template contains duplicate variables (var1, var2).
+[PATH-3-007] |2| {/paths[/pathstest25/]->null} :: Path semantically identical to other paths.
+[PATH-3-007] |2| {/paths[/pathstest25]->null} :: Path semantically identical to other paths.
+[PATH-3-007] |2| {/paths[/pathstest26/{var}/]->null} :: Path semantically identical to other paths.
+[PATH-3-007] |2| {/paths[/pathstest26/{var}]->null} :: Path semantically identical to other paths.
+[PATH-3-007] |2| {/paths[/pathstest27/{var2}/]->null} :: Path semantically identical to other paths.
+[PATH-3-007] |2| {/paths[/pathstest27/{var1}]->null} :: Path semantically identical to other paths.
 [COMP-3-001] |2| {/components/schemas[Pet+Foo]->name} :: Schema Definition Name is not valid.
 [COMP-3-003] |2| {/components/responses[The Response]->name} :: Response Definition Name is not valid.
 [COMP-3-002] |2| {/components/parameters[Some$Parameter]->parameterName} :: Parameter Definition Name is not valid.
@@ -367,10 +383,10 @@ describe("Validation (3.0)", () => {
 [COMP-3-008] |2| {/components/links[Link*Twelve]->name} :: The Link Definition Name is not valid.
 [COMP-3-009] |2| {/components/callbacks[Invalid Callback Name]->name} :: The Callback Definition Name is not valid.
 [SREQ-3-001] |2| {/security[1]->null} :: "MissingAuth" does not match a declared Security Scheme.`;
-
+    
         assertValidationOutput(actual, expected);
     });
-
+    
     it("Invalid Property Value", () => {
         let json: any = readJSON('tests/fixtures/validation/3.0/invalid-property-value.json');
         let document: Oas30Document = library.createDocument(json) as Oas30Document;


### PR DESCRIPTION
….g. /test{var}. Checks for duplicate variables within a path and checks for semantically identical paths.