### PR TITLE
Validation Rule: add validation to require `operationId`

### DIFF
--- a/src/validation/2.0/required-property.rule.ts
+++ b/src/validation/2.0/required-property.rule.ts
@@ -93,6 +93,7 @@ export class Oas20RequiredPropertyValidationRule extends Oas20ValidationRule {
 
     public visitOperation(node: Oas20Operation): void {
         this.requireProperty("OP-007", node, "responses", "Operation must have at least one response.");
+        this.requireProperty("OP-008", node, "operationId", "Operation is missing a operation id.");
     }
 
     public visitExternalDocumentation(node: Oas20ExternalDocumentation): void {

--- a/src/validation/3.0/required-property.rule.ts
+++ b/src/validation/3.0/required-property.rule.ts
@@ -130,6 +130,7 @@ export class Oas30RequiredPropertyValidationRule extends Oas30ValidationRule {
 
     public visitOperation(node: Oas30Operation): void {
         this.requireProperty("OP-3-004", node, "responses", "Operation must have at least one response.");
+        this.requireProperty("OP-3-007", node, "operationId", "Operation is missing a operation id.");
     }
 
     public visitParameter(node: Oas30Parameter): void {

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -41,7 +41,19 @@ export interface IOasValidationSeverityRegistry {
 
 export class DefaultValidationSeverityRegistry implements IOasValidationSeverityRegistry {
 
+    /**
+     * By default validation some rules are provided but they do not reflect the requirements in the OpenAPI specification
+     */
+    public static IGNORED_BY_DEFAULT = [
+        "OP-008", // operationId required
+        "OP-3-007" // operationId required
+    ];
+
     public lookupSeverity(ruleCode: string): OasValidationProblemSeverity {
+        if (DefaultValidationSeverityRegistry.IGNORED_BY_DEFAULT.indexOf(ruleCode) >= 0) {
+            return OasValidationProblemSeverity.ignore;
+        }
+
         return OasValidationProblemSeverity.medium;
     }
 

--- a/tests/fixtures/validation/2.0/operation-id.json
+++ b/tests/fixtures/validation/2.0/operation-id.json
@@ -1,0 +1,32 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Operation ID example"
+  },
+  "paths": {
+    "/path": {
+      "get": {
+        "operationId": "operationId1",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/validation/3.0/operation-id.json
+++ b/tests/fixtures/validation/3.0/operation-id.json
@@ -1,0 +1,26 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Operation ID example"
+  },
+  "paths": {
+    "/path": {
+      "get": {
+        "operationId": "operationId1",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -25,6 +25,16 @@ import {Oas30Document} from "../src/models/3.0/document.model";
 import * as JsDiff from "diff";
 import {IOasValidationSeverityRegistry, OasValidationProblemSeverity} from "../src/validation/validation";
 
+class CustomSeverities implements IOasValidationSeverityRegistry {
+
+    constructor(private severity: OasValidationProblemSeverity) {}
+
+    public lookupSeverity(ruleCode: string): OasValidationProblemSeverity {
+        return this.severity;
+    }
+
+}
+
 
 function errorsAsString(errors: OasValidationProblem[]): string {
     let es: string[] = [];
@@ -283,6 +293,18 @@ describe("Validation (2.0)", () => {
         assertValidationOutput(actual, expected);
     });
 
+    it("Required operationId if un-ignored", () => {
+        let json: any = readJSON('tests/fixtures/validation/2.0/operation-id.json');
+        let document: Oas20Document = library.createDocument(json) as Oas20Document;
+
+        let node: OasNode = document;
+        let errors: OasValidationProblem[] = library.validate(node, true, new CustomSeverities(OasValidationProblemSeverity.high));
+
+        let actual: string = errorsAsString(errors);
+        let expected: string = `[OP-008] |3| {/paths[/path]/post->operationId} :: Operation is missing a operation id.`;
+
+        assertValidationOutput(actual, expected);
+    });
 });
 
 
@@ -620,16 +642,6 @@ describe("Validation (3.0)", () => {
 
     });
 
-    class CustomSeverities implements IOasValidationSeverityRegistry {
-
-        constructor(private severity: OasValidationProblemSeverity) {}
-
-        public lookupSeverity(ruleCode: string): OasValidationProblemSeverity {
-            return this.severity;
-        }
-
-    }
-
     it("Validation Problem List", () => {
         let json: any = readJSON('tests/fixtures/validation/3.0/invalid-property-value.json');
         let document: Oas30Document = library.createDocument(json) as Oas30Document;
@@ -675,4 +687,16 @@ describe("Validation (3.0)", () => {
         assertValidationOutput(actual, expected);
     });
 
+    it("Required operationId if un-ignored", () => {
+        let json: any = readJSON('tests/fixtures/validation/3.0/operation-id.json');
+        let document: Oas30Document = library.createDocument(json) as Oas30Document;
+
+        let node: OasNode = document;
+        let errors: OasValidationProblem[] = library.validate(node, true, new CustomSeverities(OasValidationProblemSeverity.high));
+
+        let actual: string = errorsAsString(errors);
+        let expected: string = `[OP-3-007] |3| {/paths[/path]/post->operationId} :: Operation is missing a operation id.`;
+
+        assertValidationOutput(actual, expected);
+    });
 });


### PR DESCRIPTION
`operationId` of operations is not required by the specification so this sets the severity of it in the default `DefaultValidationSeverityRegistry` to `ignored`.

This is the first, probably the simplest validation to implement, needed for the use of Apicurio in Syndesis.